### PR TITLE
add getblockheader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+.idea

--- a/src/bitcoinapi/bitcoinapi.cpp
+++ b/src/bitcoinapi/bitcoinapi.cpp
@@ -941,6 +941,42 @@ int BitcoinAPI::getblockcount() {
 	return result.asInt();
 }
 
+std::string BitcoinAPI::getblockheaderhex(const std::string& blockhash) {
+	string command = "getblockheader";
+	Value params, result;
+	params.append(blockhash);
+	params.append(false);
+
+    result = sendcommand(command, params);
+	return result.asString();
+}
+
+blockheader_t BitcoinAPI::getblockheaderjson(const std::string& blockhash) {
+	string command = "getblockheader";
+	Value params, result;
+	blockheader_t ret;
+
+	params.append(blockhash);
+	result = sendcommand(command, params);
+
+	ret.hash = result["hash"].asString();
+	ret.confirmations = result["confirmations"].asInt();
+	ret.height = result["height"].asInt();
+	ret.version = result["version"].asInt();
+	ret.versionHex = result["verionHex"].asString();
+	ret.merkleroot = result["merkleroot"].asString();
+	ret.mediantime = result["mediantime"].asUInt();
+	ret.nonce = result["nonce"].asUInt();
+	ret.bits = result["bits"].asString();
+	ret.difficulty = result["difficulty"].asDouble();
+	ret.chainwork = result["chainwork"].asString();
+	ret.previousblockhash = result["previousblockhash"].asString();
+	ret.nextblockhash = result["nextblockhash"].asString();
+
+	return ret;
+}
+
+
 void BitcoinAPI::setgenerate(bool generate, int genproclimit) {
 	string command = "setgenerate";
 	Value params;

--- a/src/bitcoinapi/bitcoinapi.h
+++ b/src/bitcoinapi/bitcoinapi.h
@@ -122,6 +122,10 @@ public:
     blockinfo_t getblock(const std::string& blockhash);
     int getblockcount();
 
+    /* === blockchain === */
+    blockheader_t getblockheaderjson(const std::string& blockhash);
+    std::string getblockheaderhex(const std::string& blockhash);
+
     void setgenerate(bool generate, int genproclimit = -1);
     bool getgenerate();
     double getdifficulty();

--- a/src/bitcoinapi/types.h
+++ b/src/bitcoinapi/types.h
@@ -245,6 +245,22 @@
 		std::string nextblockhash;
 	};
 
+	struct blockheader_t {
+		std::string hash;
+		int confirmations;
+		int height;
+		int version;
+		std::string versionHex;
+		std::string merkleroot;
+		int mediantime;
+		unsigned int nonce;
+		std::string bits;
+		double difficulty;
+		std::string chainwork;
+		std::string previousblockhash;
+		std::string nextblockhash;
+	};
+
 	struct mininginfo_t{
 		int blocks;
 		int currentblocksize;

--- a/src/test/mining.cpp
+++ b/src/test/mining.cpp
@@ -1,7 +1,10 @@
 #define BOOST_TEST_DYN_LINK
 
-#include <boost/test/unit_test.hpp>
+
 #include <algorithm>
+#include <iostream>
+#include <boost/test/unit_test.hpp>
+
 #include "main.cpp"
 
 BOOST_AUTO_TEST_SUITE(MiningTests)
@@ -78,6 +81,42 @@ BOOST_AUTO_TEST_CASE(GetBlock) {
 	std::cout << "previousblockhash: " << response.previousblockhash << std::endl;
 	std::cout << "nextblockhash: " << response.nextblockhash << std::endl << std::endl;
 	#endif
+}
+
+BOOST_AUTO_TEST_CASE(GetBlockHeaderHex) {
+
+	MyFixture fx;
+	std::string response;
+
+	NO_THROW(response = fx.btc.getblockheaderhex("00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"));
+	BOOST_REQUIRE(response == "010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000982051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1cdb606e857233e0e61bc6649ffff001d01e36299");
+
+}
+
+BOOST_AUTO_TEST_CASE(GetBlockHeaderJSON) {
+
+	MyFixture fx;
+	blockheader_t response;
+
+	NO_THROW(response = fx.btc.getblockheaderjson("00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"));
+	BOOST_REQUIRE(response.height == 1);
+
+#ifdef VERBOSE
+	std::cout << "=== getblock (10th block) ===" << std::endl;
+	std::cout << "hash: " << response.hash << std::endl;
+	std::cout << "confirmations: " << response.confirmations << std::endl;
+	std::cout << "height: " << response.height << std::endl;
+	std::cout << "version: " << response.version << std::endl;
+	std::cout << "versionHex: " << response.versionHex << std::endl;
+	std::cout << "merkleroot: " << response.merkleroot << std::endl;
+	std::cout << "mediantime: " << response.mediantime << std::endl;
+	std::cout << "nonce: " << response.nonce << std::endl;
+	std::cout << "bits: " << response.bits << std::endl;
+	std::cout << "difficulty: " << response.difficulty << std::endl;
+	std::cout << "chainwork: " << response.chainwork << std::endl;
+	std::cout << "previousblockhash: " << response.previousblockhash << std::endl;
+	std::cout << "nextblockhash: " << response.nextblockhash << std::endl << std::endl;
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(GetGenerate) {


### PR DESCRIPTION
Added support for [`getblockheader`](https://bitcoin.org/en/developer-reference#getblockheader). A test case is also added.