### PR TITLE
handling doubles

### DIFF
--- a/src/bitcoinapi/bitcoinapi.cpp
+++ b/src/bitcoinapi/bitcoinapi.cpp
@@ -12,6 +12,8 @@
 
 #include <string>
 #include <stdexcept>
+#include <iomanip>
+#include <sstream>
 #include <cmath>
 
 #include <jsonrpccpp/client.h>
@@ -30,6 +32,7 @@ using std::map;
 using std::string;
 using std::vector;
 
+using namespace std;
 
 BitcoinAPI::BitcoinAPI(const string& user, const string& password, const string& host, int port)
 : httpClient(new HttpClient("http://" + user + ":" + password + "@" + host + ":" + NumberToString(port))),
@@ -56,9 +59,11 @@ int BitcoinAPI::StringToNumber (const string &text){
 	return ss >> result ? result : 0;
 }
 
-double BitcoinAPI::RoundDouble(double num)
+string BitcoinAPI::RoundDouble(double num)
 {
-	return floor(num * pow(10,8)) / pow(10,8);
+	ostringstream os;
+	os << dec << num;
+	return os.str();
 }
 
 Value BitcoinAPI::sendcommand(const string& command, const Value& params){    
@@ -1143,7 +1148,6 @@ string BitcoinAPI::sendrawtransaction(const string& hexString, bool highFee) {
 
 	return result.asString();
 }
-
 
 string BitcoinAPI::createrawtransaction(const vector<txout_t>& inputs, const map<string,double>& amounts) {
 	string command = "createrawtransaction";

--- a/src/bitcoinapi/bitcoinapi.cpp
+++ b/src/bitcoinapi/bitcoinapi.cpp
@@ -62,7 +62,8 @@ int BitcoinAPI::StringToNumber (const string &text){
 string BitcoinAPI::RoundDouble(double num)
 {
 	ostringstream os;
-	os << dec << num;
+	os << fixed << dec << setprecision(8) << num;
+cout << "using " << os.str() << endl;
 	return os.str();
 }
 

--- a/src/bitcoinapi/bitcoinapi.h
+++ b/src/bitcoinapi/bitcoinapi.h
@@ -32,7 +32,7 @@ public:
     Json::Value sendcommand(const std::string& command, const Json::Value& params);
     std::string NumberToString(int num);
     int StringToNumber(const std::string& str);
-    double RoundDouble(double num);
+    std::string RoundDouble(double num);
 
 
     /* === Node functions === */


### PR DESCRIPTION
JSON lib is wrong when converting doubles to string. This patch convers them to string before handing them over JSONlib